### PR TITLE
fuzz: extend block_index_tree fuzz test for pruned blocks in forks

### DIFF
--- a/src/node/blockstorage.cpp
+++ b/src/node/blockstorage.cpp
@@ -255,6 +255,18 @@ CBlockIndex* BlockManager::AddToBlockIndex(const CBlockHeader& block, CBlockInde
     return pindexNew;
 }
 
+void BlockManager::AddUnlinkedBlock(CBlockIndex* block)
+{
+    AssertLockHeld(cs_main);
+    Assume(block != nullptr);
+    Assume(block->nStatus & BLOCK_HAVE_DATA);
+    auto range = m_blocks_unlinked.equal_range(block->pprev);
+    for (auto it = range.first; it != range.second; ++it) {
+        if (it->second == block) return;  // don't insert duplicates
+    }
+    m_blocks_unlinked.emplace(block->pprev, block);
+}
+
 void BlockManager::PruneOneBlockFile(const int fileNumber)
 {
     AssertLockHeld(cs_main);
@@ -481,7 +493,7 @@ bool BlockManager::LoadBlockIndex(const std::optional<uint256>& snapshot_blockha
                     pindex->m_chain_tx_count = pindex->pprev->m_chain_tx_count + pindex->nTx;
                 } else {
                     pindex->m_chain_tx_count = 0;
-                    m_blocks_unlinked.insert(std::make_pair(pindex->pprev, pindex));
+                    AddUnlinkedBlock(pindex);
                 }
             } else {
                 pindex->m_chain_tx_count = pindex->nTx;

--- a/src/node/blockstorage.h
+++ b/src/node/blockstorage.h
@@ -350,7 +350,6 @@ public:
 
     /**
      * All pairs A->B, where A (or one of its ancestors) misses transactions, but B has transactions.
-     * Pruned nodes may have entries where B is missing data.
      */
     std::multimap<CBlockIndex*, CBlockIndex*> m_blocks_unlinked;
 

--- a/src/node/blockstorage.h
+++ b/src/node/blockstorage.h
@@ -352,6 +352,7 @@ public:
      * All pairs A->B, where A (or one of its ancestors) misses transactions, but B has transactions.
      */
     std::multimap<CBlockIndex*, CBlockIndex*> m_blocks_unlinked;
+    void AddUnlinkedBlock(CBlockIndex* block) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 
     std::unique_ptr<BlockTreeDB> m_block_tree_db GUARDED_BY(::cs_main);
 

--- a/src/test/fuzz/block_index_tree.cpp
+++ b/src/test/fuzz/block_index_tree.cpp
@@ -58,6 +58,7 @@ FUZZ_TARGET(block_index_tree, .init = initialize_block_index_tree)
     std::vector<CBlockIndex*> blocks;
     blocks.push_back(genesis);
     bool abort_run{false};
+    std::vector<std::pair<CBlockIndex*, CBlockIndex*>> deferred_unlinked_erases;
     DPRINT("START\n");
     DPRINT("chain.m_chain.Height() = %d\n", chainman.ActiveChainstate().m_chain.Height());
     DPRINT("Genesis block (height = %d, block hash = %s, chainwork = %s)\n", genesis->nHeight, genesis->GetBlockHash().ToString().c_str(), genesis->nChainWork.ToString().c_str());
@@ -213,15 +214,15 @@ FUZZ_TARGET(block_index_tree, .init = initialize_block_index_tree)
                     prune_block->nFile = 0;
                     prune_block->nDataPos = 0;
                     prune_block->nUndoPos = 0;
-                    // auto range = blockman.m_blocks_unlinked.equal_range(prune_block->pprev);
-                    // while (range.first != range.second) {
-                    //     std::multimap<CBlockIndex*, CBlockIndex*>::iterator _it = range.first;
-                    //     range.first++;
-                    //     if (_it->second == prune_block) {
-                    //         DPRINT("removing from m_blocks_unlinked: %s -> %s\n", _it->first->ToString().c_str(), _it->second->ToString().c_str());
-                    //         blockman.m_blocks_unlinked.erase(_it);
-                    //     }
-                    // }
+                    auto range = blockman.m_blocks_unlinked.equal_range(prune_block->pprev);
+                    while (range.first != range.second) {
+                        std::multimap<CBlockIndex*, CBlockIndex*>::iterator _it = range.first;
+                        range.first++;
+                        if (_it->second == prune_block) {
+                            DPRINT("will remove from m_blocks_unlinked later if it is still there: %s -> %s\n", _it->first->ToString().c_str(), _it->second->ToString().c_str());
+                            deferred_unlinked_erases.emplace_back(prune_block->pprev, prune_block);
+                        }
+                    }
                     pruned_blocks.push_back(prune_block);
                 }
                 DPRINT("\n\n");
@@ -248,6 +249,19 @@ FUZZ_TARGET(block_index_tree, .init = initialize_block_index_tree)
     }
     if (!abort_run) {
         DPRINT("Running CBI - later we can take it out of if\n");
+        {
+            LOCK(cs_main);
+            for (const auto& [key, val] : deferred_unlinked_erases) {
+                auto range = blockman.m_blocks_unlinked.equal_range(key);
+                for (auto it = range.first; it != range.second; ) {
+                    if (it->second == val) {
+                        it = blockman.m_blocks_unlinked.erase(it);
+                    } else {
+                        ++it;
+                    }
+                }
+            }
+        }
         chainman.CheckBlockIndex();
     }
     DPRINT("END\n");

--- a/src/test/fuzz/block_index_tree.cpp
+++ b/src/test/fuzz/block_index_tree.cpp
@@ -19,14 +19,6 @@
 #include <ranges>
 #include <vector>
 
-#define DEBUGOUTPUT 0
-
-#if DEBUGOUTPUT
-#define DPRINT(...) do { std::fprintf(stderr, __VA_ARGS__); } while (0)
-#else
-#define DPRINT(...) do {} while (0)
-#endif
-
 const TestingSetup* g_setup;
 
 CBlockHeader ConsumeBlockHeader(FuzzedDataProvider& provider, uint256 prev_hash, int& nonce_counter)
@@ -59,9 +51,6 @@ FUZZ_TARGET(block_index_tree, .init = initialize_block_index_tree)
     blocks.push_back(genesis);
     bool abort_run{false};
     std::vector<std::pair<CBlockIndex*, CBlockIndex*>> deferred_unlinked_erases;
-    DPRINT("START\n");
-    DPRINT("chain.m_chain.Height() = %d\n", chainman.ActiveChainstate().m_chain.Height());
-    DPRINT("Genesis block (height = %d, block hash = %s, chainwork = %s)\n", genesis->nHeight, genesis->GetBlockHash().ToString().c_str(), genesis->nChainWork.ToString().c_str());
 
     std::vector<CBlockIndex*> pruned_blocks;
 
@@ -73,36 +62,25 @@ FUZZ_TARGET(block_index_tree, .init = initialize_block_index_tree)
             [&] {
                 // Receive a header building on an existing valid one. This assumes headers are valid, so PoW is not relevant here.
                 LOCK(cs_main);
-                DPRINT("1. Receive header and build on existing one\n");
                 CBlockIndex* prev_block = PickValue(fuzzed_data_provider, blocks);
-                DPRINT("prev_block (height = %d, block hash = %s, chainwork = %s)\n", prev_block->nHeight, prev_block->GetBlockHash().ToString().c_str(), prev_block->nChainWork.ToString().c_str());
                 if (!(prev_block->nStatus & BLOCK_FAILED_VALID)) {
                     CBlockHeader header = ConsumeBlockHeader(fuzzed_data_provider, prev_block->GetBlockHash(), nonce_counter);
-                    DPRINT("chainman.m_best_header before AddToBlockIndex (height = %d, block hash = %s,chainwork = %s)\n", chainman.m_best_header->nHeight, chainman.m_best_header->GetBlockHash().ToString().c_str(), (chainman.m_best_header)->nChainWork.ToString().c_str());
                     CBlockIndex* index = blockman.AddToBlockIndex(header, chainman.m_best_header);
-                    DPRINT("chainman.m_best_header after AddToBlockIndex (height = %d, block hash = %s, chainwork = %s)\n", chainman.m_best_header->nHeight, chainman.m_best_header->GetBlockHash().ToString().c_str(), (chainman.m_best_header)->nChainWork.ToString().c_str());
-                    DPRINT("index (height = %d, block hash = %s, chainwork = %s)\n", index->nHeight, index->GetBlockHash().ToString().c_str(), index->nChainWork.ToString().c_str());
                     assert(index->nStatus & BLOCK_VALID_TREE);
                     assert(index->pprev == prev_block);
                     blocks.push_back(index);
-                } else {
-                    DPRINT("prev_block is BLOCK_FAILED_MASK, don't build on top of prev_block\n");
                 }
-                DPRINT("\n\n");
             },
             [&] {
                 // Receive a full block (valid or invalid) for an existing header, but don't attempt to connect it yet
                 LOCK(cs_main);
-                DPRINT("2. Receive full block (valid or invalid) for an existing header but don't CONNECT\n");
                 CBlockIndex* index = PickValue(fuzzed_data_provider, blocks);
-                DPRINT("index (height = %d, block hash = %s, chainwork = %s)\n", index->nHeight, index->GetBlockHash().ToString().c_str(), index->nChainWork.ToString().c_str());
                 // Must be new to us and not known to be invalid (e.g. because of an invalid ancestor).
                 if (index->nTx == 0 && !(index->nStatus & BLOCK_FAILED_VALID)) {
                     if (fuzzed_data_provider.ConsumeBool()) { // Invalid
                         BlockValidationState state;
                         state.Invalid(BlockValidationResult::BLOCK_CONSENSUS, "consensus-invalid");
                         chainman.InvalidBlockFound(index, state);
-                        DPRINT("call InvalidBlockFound, index is now BLOCK_FAILED_VALID\n");
                     } else {
                         size_t nTx = fuzzed_data_provider.ConsumeIntegralInRange<size_t>(1, 1000);
                         CBlock block; // Dummy block, so that ReceivedBlockTransactions can infer a nTx value.
@@ -111,19 +89,12 @@ FUZZ_TARGET(block_index_tree, .init = initialize_block_index_tree)
                         chainman.ReceivedBlockTransactions(block, index, pos);
                         assert(index->nStatus & BLOCK_VALID_TRANSACTIONS);
                         assert(index->nStatus & BLOCK_HAVE_DATA);
-                        DPRINT("call ReceivedBlockTransactions, index is now BLOCK_VALID_TRANSACTIONS\n");
                     }
-                } else {
-                    DPRINT("index->nTx == 0 = %d\n", index->nTx == 0);
-                    DPRINT("index->nStatus & BLOCK_FAILED_MASK = %d\n", index->nStatus & BLOCK_FAILED_VALID);
-                    DPRINT("Don't do anything since index->nTx == %d is not 0 && is BLOCK_FAILED_MASK\n", index->nTx);
                 }
-                DPRINT("\n\n");
             },
             [&] {
                 // Simplified ActivateBestChain(): Try to move to a chain with more work - with the possibility of finding blocks to be invalid on the way
                 LOCK(cs_main);
-                DPRINT("2.Simplified ActivateBestChain()\n");
                 auto& chain = chainman.ActiveChain();
                 CBlockIndex* old_tip = chain.Tip();
                 assert(old_tip);
@@ -133,25 +104,18 @@ FUZZ_TARGET(block_index_tree, .init = initialize_block_index_tree)
                     if (best_tip == chain.Tip()) break; // Nothing to do
                     // Rewind chain to forking point
                     const CBlockIndex* fork = chain.FindFork(best_tip);
-                    DPRINT("fork (height = %d, block hash = %s, nStatus = %s, chainwork = %s)\n", fork->nHeight, fork->GetBlockHash().ToString().c_str(), fork->nChainWork.ToString().c_str());
                     // If we can't go back to the fork point due to pruned data, abort this run. In reality, a pruned node would also currently just crash in this scenario.
                     // This is very unlikely to happen due to the minimum pruning threshold of 550MiB.
                     CBlockIndex* it = chain.Tip();
-                    DPRINT("chain.Tip() (height = %d, block hash = %s, nStatus = %s, chainwork = %s)\n", it->nHeight, it->GetBlockHash().ToString().c_str(), it->nChainWork.ToString().c_str());
-                    DPRINT("we go back to fork point\n");
                     while (it && it->nHeight != fork->nHeight) {
                         if (!(it->nStatus & BLOCK_HAVE_UNDO)) {
                             assert(blockman.m_have_pruned);
                             abort_run = true;
-                            DPRINT("pruned block, exit\n");
                             return;
                         }
                         it = it->pprev;
                     }
                     chain.SetTip(*chain[fork->nHeight]);
-                    it = chain.Tip();
-                    DPRINT("new chain.Tip() (height = %d, block hash = %s, nStatus = %s, chainwork = %s)\n", it->nHeight, it->GetBlockHash().ToString().c_str(), it->nChainWork.ToString().c_str());
-
 
                     // Prepare new blocks to connect
                     std::vector<CBlockIndex*> to_connect;
@@ -161,28 +125,23 @@ FUZZ_TARGET(block_index_tree, .init = initialize_block_index_tree)
                         it = it->pprev;
                     }
                     // Connect blocks, possibly fail
-                    DPRINT("Loop through possible blocks to connect to (same as blocks from tip to fork)\n");
                     for (CBlockIndex* block : to_connect | std::views::reverse) {
                         assert(!(block->nStatus & BLOCK_FAILED_VALID));
                         assert(block->nStatus & BLOCK_HAVE_DATA);
                         if (!block->IsValid(BLOCK_VALID_SCRIPTS)) {
-                            DPRINT("block (height = %d, block hash = %s, chainwork = %s)\n", block->nHeight, block->GetBlockHash().ToString().c_str(), block->nChainWork.ToString().c_str());
                             if (fuzzed_data_provider.ConsumeBool()) { // Invalid
                                 BlockValidationState state;
                                 state.Invalid(BlockValidationResult::BLOCK_CONSENSUS, "consensus-invalid");
                                 chainman.InvalidBlockFound(block, state);
                                 // This results in duplicate calls to InvalidChainFound, but mirrors the behavior in validation
                                 chainman.InvalidChainFound(to_connect.front());
-                                DPRINT("mark as invalid block and chain and EXIT\n");
                                 break;
                             } else {
                                 block->RaiseValidity(BLOCK_VALID_SCRIPTS);
                                 block->nStatus |= BLOCK_HAVE_UNDO;
-                                DPRINT("mark as BLOCK_VALID_SCRIPTS and LOOP\n");
                             }
                         }
                         chain.SetTip(*block);
-                        DPRINT("set block as new tip\n");
                         chainman.ActiveChainstate().PruneBlockIndexCandidates();
                         // ActivateBestChainStep may release cs_main / not connect all blocks in one go - but only if we have at least as much chain work as we had at the start.
                         if (block->nChainWork > old_tip->nChainWork && fuzzed_data_provider.ConsumeBool()) {
@@ -191,24 +150,20 @@ FUZZ_TARGET(block_index_tree, .init = initialize_block_index_tree)
                     }
                 } while (node::CBlockIndexWorkComparator()(chain.Tip(), old_tip));
                 assert(chain.Tip()->nChainWork >= old_tip->nChainWork);
-                DPRINT("\n\n");
             },
             [&] {
                 // Prune chain - dealing with block files is beyond the scope of this test, so just prune random blocks, making no assumptions
                 // about what blocks are pruned together because they are in the same block file.
                 LOCK(cs_main);
-                DPRINT("4. Prune chain\n");
                 auto& chain = chainman.ActiveChain();
                 // int prune_height = fuzzed_data_provider.ConsumeIntegralInRange<int>(0, chain.Height());
                 // CBlockIndex* prune_block{chain[prune_height]};
                 CBlockIndex* prune_block = PickValue(fuzzed_data_provider, blocks);
-                DPRINT("prune_height = %d\n", prune_block->nHeight);
                 if (prune_block != chain.Tip() && (prune_block->nStatus & BLOCK_HAVE_DATA)) {
                     if (chainman.ActiveChainstate().setBlockIndexCandidates.contains(prune_block)) {
                         return;
                     }
                     blockman.m_have_pruned = true;
-                    DPRINT("pruning block (height = %d, block hash = %s, chainwork = %s)\n", prune_block->nHeight, prune_block->GetBlockHash().ToString().c_str(), prune_block->nChainWork.ToString().c_str());
                     prune_block->nStatus &= ~BLOCK_HAVE_DATA;
                     prune_block->nStatus &= ~BLOCK_HAVE_UNDO;
                     prune_block->nFile = 0;
@@ -219,18 +174,16 @@ FUZZ_TARGET(block_index_tree, .init = initialize_block_index_tree)
                         std::multimap<CBlockIndex*, CBlockIndex*>::iterator _it = range.first;
                         range.first++;
                         if (_it->second == prune_block) {
-                            DPRINT("will remove from m_blocks_unlinked later if it is still there: %s -> %s\n", _it->first->ToString().c_str(), _it->second->ToString().c_str());
                             deferred_unlinked_erases.emplace_back(prune_block->pprev, prune_block);
+                            blockman.m_blocks_unlinked.erase(_it);
                         }
                     }
                     pruned_blocks.push_back(prune_block);
                 }
-                DPRINT("\n\n");
             },
             [&] {
                 // Download a previously pruned block
                 LOCK(cs_main);
-                DPRINT("4. Download Prune block again\n");
                 size_t num_pruned = pruned_blocks.size();
                 if (num_pruned == 0) return;
                 size_t i = fuzzed_data_provider.ConsumeIntegralInRange<size_t>(0, num_pruned - 1);
@@ -256,16 +209,13 @@ FUZZ_TARGET(block_index_tree, .init = initialize_block_index_tree)
                 CBlock block;
                 block.vtx = std::vector<CTransactionRef>(index->nTx); // Set the number of tx to the prior value.
                 FlatFilePos pos(0, fuzzed_data_provider.ConsumeIntegralInRange<int>(1, 1000));
-                DPRINT("receiving previously pruned block (height = %d, block hash = %s, chainwork = %s)\n", index->nHeight, index->GetBlockHash().ToString().c_str(), index->nChainWork.ToString().c_str());
                 chainman.ReceivedBlockTransactions(block, index, pos);
                 assert(index->nStatus & BLOCK_VALID_TRANSACTIONS);
                 assert(index->nStatus & BLOCK_HAVE_DATA);
                 pruned_blocks.erase(pruned_blocks.begin() + i);
-                DPRINT("\n\n");
             });
     }
     if (!abort_run) {
-        DPRINT("Running CBI - later we can take it out of if\n");
         {
             LOCK(cs_main);
             for (const auto& [key, val] : deferred_unlinked_erases) {
@@ -281,7 +231,6 @@ FUZZ_TARGET(block_index_tree, .init = initialize_block_index_tree)
         }
         chainman.CheckBlockIndex();
     }
-    DPRINT("END\n");
 
     // clean up global state changed by last iteration and prepare for next iteration
     {

--- a/src/test/fuzz/block_index_tree.cpp
+++ b/src/test/fuzz/block_index_tree.cpp
@@ -19,6 +19,14 @@
 #include <ranges>
 #include <vector>
 
+#define DEBUGOUTPUT 0
+
+#if DEBUGOUTPUT
+#define DPRINT(...) do { std::fprintf(stderr, __VA_ARGS__); } while (0)
+#else
+#define DPRINT(...) do {} while (0)
+#endif
+
 const TestingSetup* g_setup;
 
 CBlockHeader ConsumeBlockHeader(FuzzedDataProvider& provider, uint256 prev_hash, int& nonce_counter)
@@ -50,6 +58,9 @@ FUZZ_TARGET(block_index_tree, .init = initialize_block_index_tree)
     std::vector<CBlockIndex*> blocks;
     blocks.push_back(genesis);
     bool abort_run{false};
+    DPRINT("START\n");
+    DPRINT("chain.m_chain.Height() = %d\n", chainman.ActiveChainstate().m_chain.Height());
+    DPRINT("Genesis block (height = %d, block hash = %s, chainwork = %s)\n", genesis->nHeight, genesis->GetBlockHash().ToString().c_str(), genesis->nChainWork.ToString().c_str());
 
     std::vector<CBlockIndex*> pruned_blocks;
 
@@ -61,25 +72,36 @@ FUZZ_TARGET(block_index_tree, .init = initialize_block_index_tree)
             [&] {
                 // Receive a header building on an existing valid one. This assumes headers are valid, so PoW is not relevant here.
                 LOCK(cs_main);
+                DPRINT("1. Receive header and build on existing one\n");
                 CBlockIndex* prev_block = PickValue(fuzzed_data_provider, blocks);
+                DPRINT("prev_block (height = %d, block hash = %s, chainwork = %s)\n", prev_block->nHeight, prev_block->GetBlockHash().ToString().c_str(), prev_block->nChainWork.ToString().c_str());
                 if (!(prev_block->nStatus & BLOCK_FAILED_VALID)) {
                     CBlockHeader header = ConsumeBlockHeader(fuzzed_data_provider, prev_block->GetBlockHash(), nonce_counter);
+                    DPRINT("chainman.m_best_header before AddToBlockIndex (height = %d, block hash = %s,chainwork = %s)\n", chainman.m_best_header->nHeight, chainman.m_best_header->GetBlockHash().ToString().c_str(), (chainman.m_best_header)->nChainWork.ToString().c_str());
                     CBlockIndex* index = blockman.AddToBlockIndex(header, chainman.m_best_header);
+                    DPRINT("chainman.m_best_header after AddToBlockIndex (height = %d, block hash = %s, chainwork = %s)\n", chainman.m_best_header->nHeight, chainman.m_best_header->GetBlockHash().ToString().c_str(), (chainman.m_best_header)->nChainWork.ToString().c_str());
+                    DPRINT("index (height = %d, block hash = %s, chainwork = %s)\n", index->nHeight, index->GetBlockHash().ToString().c_str(), index->nChainWork.ToString().c_str());
                     assert(index->nStatus & BLOCK_VALID_TREE);
                     assert(index->pprev == prev_block);
                     blocks.push_back(index);
+                } else {
+                    DPRINT("prev_block is BLOCK_FAILED_MASK, don't build on top of prev_block\n");
                 }
+                DPRINT("\n\n");
             },
             [&] {
                 // Receive a full block (valid or invalid) for an existing header, but don't attempt to connect it yet
                 LOCK(cs_main);
+                DPRINT("2. Receive full block (valid or invalid) for an existing header but don't CONNECT\n");
                 CBlockIndex* index = PickValue(fuzzed_data_provider, blocks);
+                DPRINT("index (height = %d, block hash = %s, chainwork = %s)\n", index->nHeight, index->GetBlockHash().ToString().c_str(), index->nChainWork.ToString().c_str());
                 // Must be new to us and not known to be invalid (e.g. because of an invalid ancestor).
                 if (index->nTx == 0 && !(index->nStatus & BLOCK_FAILED_VALID)) {
                     if (fuzzed_data_provider.ConsumeBool()) { // Invalid
                         BlockValidationState state;
                         state.Invalid(BlockValidationResult::BLOCK_CONSENSUS, "consensus-invalid");
                         chainman.InvalidBlockFound(index, state);
+                        DPRINT("call InvalidBlockFound, index is now BLOCK_FAILED_VALID\n");
                     } else {
                         size_t nTx = fuzzed_data_provider.ConsumeIntegralInRange<size_t>(1, 1000);
                         CBlock block; // Dummy block, so that ReceivedBlockTransactions can infer a nTx value.
@@ -88,12 +110,19 @@ FUZZ_TARGET(block_index_tree, .init = initialize_block_index_tree)
                         chainman.ReceivedBlockTransactions(block, index, pos);
                         assert(index->nStatus & BLOCK_VALID_TRANSACTIONS);
                         assert(index->nStatus & BLOCK_HAVE_DATA);
+                        DPRINT("call ReceivedBlockTransactions, index is now BLOCK_VALID_TRANSACTIONS\n");
                     }
+                } else {
+                    DPRINT("index->nTx == 0 = %d\n", index->nTx == 0);
+                    DPRINT("index->nStatus & BLOCK_FAILED_MASK = %d\n", index->nStatus & BLOCK_FAILED_VALID);
+                    DPRINT("Don't do anything since index->nTx == %d is not 0 && is BLOCK_FAILED_MASK\n", index->nTx);
                 }
+                DPRINT("\n\n");
             },
             [&] {
                 // Simplified ActivateBestChain(): Try to move to a chain with more work - with the possibility of finding blocks to be invalid on the way
                 LOCK(cs_main);
+                DPRINT("2.Simplified ActivateBestChain()\n");
                 auto& chain = chainman.ActiveChain();
                 CBlockIndex* old_tip = chain.Tip();
                 assert(old_tip);
@@ -103,18 +132,25 @@ FUZZ_TARGET(block_index_tree, .init = initialize_block_index_tree)
                     if (best_tip == chain.Tip()) break; // Nothing to do
                     // Rewind chain to forking point
                     const CBlockIndex* fork = chain.FindFork(best_tip);
+                    DPRINT("fork (height = %d, block hash = %s, nStatus = %s, chainwork = %s)\n", fork->nHeight, fork->GetBlockHash().ToString().c_str(), fork->nChainWork.ToString().c_str());
                     // If we can't go back to the fork point due to pruned data, abort this run. In reality, a pruned node would also currently just crash in this scenario.
                     // This is very unlikely to happen due to the minimum pruning threshold of 550MiB.
                     CBlockIndex* it = chain.Tip();
+                    DPRINT("chain.Tip() (height = %d, block hash = %s, nStatus = %s, chainwork = %s)\n", it->nHeight, it->GetBlockHash().ToString().c_str(), it->nChainWork.ToString().c_str());
+                    DPRINT("we go back to fork point\n");
                     while (it && it->nHeight != fork->nHeight) {
                         if (!(it->nStatus & BLOCK_HAVE_UNDO)) {
                             assert(blockman.m_have_pruned);
                             abort_run = true;
+                            DPRINT("pruned block, exit\n");
                             return;
                         }
                         it = it->pprev;
                     }
                     chain.SetTip(*chain[fork->nHeight]);
+                    it = chain.Tip();
+                    DPRINT("new chain.Tip() (height = %d, block hash = %s, nStatus = %s, chainwork = %s)\n", it->nHeight, it->GetBlockHash().ToString().c_str(), it->nChainWork.ToString().c_str());
+
 
                     // Prepare new blocks to connect
                     std::vector<CBlockIndex*> to_connect;
@@ -124,23 +160,28 @@ FUZZ_TARGET(block_index_tree, .init = initialize_block_index_tree)
                         it = it->pprev;
                     }
                     // Connect blocks, possibly fail
+                    DPRINT("Loop through possible blocks to connect to (same as blocks from tip to fork)\n");
                     for (CBlockIndex* block : to_connect | std::views::reverse) {
                         assert(!(block->nStatus & BLOCK_FAILED_VALID));
                         assert(block->nStatus & BLOCK_HAVE_DATA);
                         if (!block->IsValid(BLOCK_VALID_SCRIPTS)) {
+                            DPRINT("block (height = %d, block hash = %s, chainwork = %s)\n", block->nHeight, block->GetBlockHash().ToString().c_str(), block->nChainWork.ToString().c_str());
                             if (fuzzed_data_provider.ConsumeBool()) { // Invalid
                                 BlockValidationState state;
                                 state.Invalid(BlockValidationResult::BLOCK_CONSENSUS, "consensus-invalid");
                                 chainman.InvalidBlockFound(block, state);
                                 // This results in duplicate calls to InvalidChainFound, but mirrors the behavior in validation
                                 chainman.InvalidChainFound(to_connect.front());
+                                DPRINT("mark as invalid block and chain and EXIT\n");
                                 break;
                             } else {
                                 block->RaiseValidity(BLOCK_VALID_SCRIPTS);
                                 block->nStatus |= BLOCK_HAVE_UNDO;
+                                DPRINT("mark as BLOCK_VALID_SCRIPTS and LOOP\n");
                             }
                         }
                         chain.SetTip(*block);
+                        DPRINT("set block as new tip\n");
                         chainman.ActiveChainstate().PruneBlockIndexCandidates();
                         // ActivateBestChainStep may release cs_main / not connect all blocks in one go - but only if we have at least as much chain work as we had at the start.
                         if (block->nChainWork > old_tip->nChainWork && fuzzed_data_provider.ConsumeBool()) {
@@ -149,17 +190,21 @@ FUZZ_TARGET(block_index_tree, .init = initialize_block_index_tree)
                     }
                 } while (node::CBlockIndexWorkComparator()(chain.Tip(), old_tip));
                 assert(chain.Tip()->nChainWork >= old_tip->nChainWork);
+                DPRINT("\n\n");
             },
             [&] {
                 // Prune chain - dealing with block files is beyond the scope of this test, so just prune random blocks, making no assumptions
                 // about what blocks are pruned together because they are in the same block file.
                 LOCK(cs_main);
+                DPRINT("4. Prune chain\n");
                 auto& chain = chainman.ActiveChain();
                 // int prune_height = fuzzed_data_provider.ConsumeIntegralInRange<int>(0, chain.Height());
                 // CBlockIndex* prune_block{chain[prune_height]};
                 CBlockIndex* prune_block = PickValue(fuzzed_data_provider, blocks);
+                DPRINT("prune_height = %d\n", prune_block->nHeight);
                 if (prune_block != chain.Tip() && (prune_block->nStatus & BLOCK_HAVE_DATA)) {
                     blockman.m_have_pruned = true;
+                    DPRINT("pruning block (height = %d, block hash = %s, chainwork = %s)\n", prune_block->nHeight, prune_block->GetBlockHash().ToString().c_str(), prune_block->nChainWork.ToString().c_str());
                     prune_block->nStatus &= ~BLOCK_HAVE_DATA;
                     prune_block->nStatus &= ~BLOCK_HAVE_UNDO;
                     prune_block->nFile = 0;
@@ -170,15 +215,18 @@ FUZZ_TARGET(block_index_tree, .init = initialize_block_index_tree)
                         std::multimap<CBlockIndex*, CBlockIndex*>::iterator _it = range.first;
                         range.first++;
                         if (_it->second == prune_block) {
+                            DPRINT("removing from m_blocks_unlinked: %s -> %s\n", _it->first->ToString().c_str(), _it->second->ToString().c_str());
                             blockman.m_blocks_unlinked.erase(_it);
                         }
                     }
                     pruned_blocks.push_back(prune_block);
                 }
+                DPRINT("\n\n");
             },
             [&] {
                 // Download a previously pruned block
                 LOCK(cs_main);
+                DPRINT("4. Download Prune block again\n");
                 size_t num_pruned = pruned_blocks.size();
                 if (num_pruned == 0) return;
                 size_t i = fuzzed_data_provider.ConsumeIntegralInRange<size_t>(0, num_pruned - 1);
@@ -187,15 +235,19 @@ FUZZ_TARGET(block_index_tree, .init = initialize_block_index_tree)
                 CBlock block;
                 block.vtx = std::vector<CTransactionRef>(index->nTx); // Set the number of tx to the prior value.
                 FlatFilePos pos(0, fuzzed_data_provider.ConsumeIntegralInRange<int>(1, 1000));
+                DPRINT("receiving previously pruned block (height = %d, block hash = %s, chainwork = %s)\n", index->nHeight, index->GetBlockHash().ToString().c_str(), index->nChainWork.ToString().c_str());
                 chainman.ReceivedBlockTransactions(block, index, pos);
                 assert(index->nStatus & BLOCK_VALID_TRANSACTIONS);
                 assert(index->nStatus & BLOCK_HAVE_DATA);
                 pruned_blocks.erase(pruned_blocks.begin() + i);
+                DPRINT("\n\n");
             });
     }
     if (!abort_run) {
+        DPRINT("Running CBI - later we can take it out of if\n");
         chainman.CheckBlockIndex();
     }
+    DPRINT("END\n");
 
     // clean up global state changed by last iteration and prepare for next iteration
     {

--- a/src/test/fuzz/block_index_tree.cpp
+++ b/src/test/fuzz/block_index_tree.cpp
@@ -236,6 +236,9 @@ FUZZ_TARGET(block_index_tree, .init = initialize_block_index_tree)
                 size_t i = fuzzed_data_provider.ConsumeIntegralInRange<size_t>(0, num_pruned - 1);
                 CBlockIndex* index = pruned_blocks[i];
                 assert(!(index->nStatus & BLOCK_HAVE_DATA));
+                if (chainman.ActiveChainstate().setBlockIndexCandidates.contains(index)) {
+                    return;
+                }
 
                 // Apply the deferred PruneOneBlockFile cleanup now, before RBT (it should have happened, but we didn't do it to protect some impossible sceanrios)
                 auto deferred_it = std::find(deferred_unlinked_erases.begin(),deferred_unlinked_erases.end(), std::make_pair(index->pprev, index));

--- a/src/test/fuzz/block_index_tree.cpp
+++ b/src/test/fuzz/block_index_tree.cpp
@@ -153,12 +153,11 @@ FUZZ_TARGET(block_index_tree, .init = initialize_block_index_tree)
             [&] {
                 // Prune chain - dealing with block files is beyond the scope of this test, so just prune random blocks, making no assumptions
                 // about what blocks are pruned together because they are in the same block file.
-                // Also don't prune blocks outside of the chain for now - this would make the fuzzer crash because of the problem described in
-                // https://github.com/bitcoin/bitcoin/issues/31512
                 LOCK(cs_main);
                 auto& chain = chainman.ActiveChain();
-                int prune_height = fuzzed_data_provider.ConsumeIntegralInRange<int>(0, chain.Height());
-                CBlockIndex* prune_block{chain[prune_height]};
+                // int prune_height = fuzzed_data_provider.ConsumeIntegralInRange<int>(0, chain.Height());
+                // CBlockIndex* prune_block{chain[prune_height]};
+                CBlockIndex* prune_block = PickValue(fuzzed_data_provider, blocks);
                 if (prune_block != chain.Tip() && (prune_block->nStatus & BLOCK_HAVE_DATA)) {
                     blockman.m_have_pruned = true;
                     prune_block->nStatus &= ~BLOCK_HAVE_DATA;

--- a/src/test/fuzz/block_index_tree.cpp
+++ b/src/test/fuzz/block_index_tree.cpp
@@ -213,15 +213,15 @@ FUZZ_TARGET(block_index_tree, .init = initialize_block_index_tree)
                     prune_block->nFile = 0;
                     prune_block->nDataPos = 0;
                     prune_block->nUndoPos = 0;
-                    auto range = blockman.m_blocks_unlinked.equal_range(prune_block->pprev);
-                    while (range.first != range.second) {
-                        std::multimap<CBlockIndex*, CBlockIndex*>::iterator _it = range.first;
-                        range.first++;
-                        if (_it->second == prune_block) {
-                            DPRINT("removing from m_blocks_unlinked: %s -> %s\n", _it->first->ToString().c_str(), _it->second->ToString().c_str());
-                            blockman.m_blocks_unlinked.erase(_it);
-                        }
-                    }
+                    // auto range = blockman.m_blocks_unlinked.equal_range(prune_block->pprev);
+                    // while (range.first != range.second) {
+                    //     std::multimap<CBlockIndex*, CBlockIndex*>::iterator _it = range.first;
+                    //     range.first++;
+                    //     if (_it->second == prune_block) {
+                    //         DPRINT("removing from m_blocks_unlinked: %s -> %s\n", _it->first->ToString().c_str(), _it->second->ToString().c_str());
+                    //         blockman.m_blocks_unlinked.erase(_it);
+                    //     }
+                    // }
                     pruned_blocks.push_back(prune_block);
                 }
                 DPRINT("\n\n");

--- a/src/test/fuzz/block_index_tree.cpp
+++ b/src/test/fuzz/block_index_tree.cpp
@@ -203,6 +203,9 @@ FUZZ_TARGET(block_index_tree, .init = initialize_block_index_tree)
                 CBlockIndex* prune_block = PickValue(fuzzed_data_provider, blocks);
                 DPRINT("prune_height = %d\n", prune_block->nHeight);
                 if (prune_block != chain.Tip() && (prune_block->nStatus & BLOCK_HAVE_DATA)) {
+                    if (chainman.ActiveChainstate().setBlockIndexCandidates.contains(prune_block)) {
+                        return;
+                    }
                     blockman.m_have_pruned = true;
                     DPRINT("pruning block (height = %d, block hash = %s, chainwork = %s)\n", prune_block->nHeight, prune_block->GetBlockHash().ToString().c_str(), prune_block->nChainWork.ToString().c_str());
                     prune_block->nStatus &= ~BLOCK_HAVE_DATA;

--- a/src/test/fuzz/block_index_tree.cpp
+++ b/src/test/fuzz/block_index_tree.cpp
@@ -236,6 +236,20 @@ FUZZ_TARGET(block_index_tree, .init = initialize_block_index_tree)
                 size_t i = fuzzed_data_provider.ConsumeIntegralInRange<size_t>(0, num_pruned - 1);
                 CBlockIndex* index = pruned_blocks[i];
                 assert(!(index->nStatus & BLOCK_HAVE_DATA));
+
+                // Apply the deferred PruneOneBlockFile cleanup now, before RBT (it should have happened, but we didn't do it to protect some impossible sceanrios)
+                auto deferred_it = std::find(deferred_unlinked_erases.begin(),deferred_unlinked_erases.end(), std::make_pair(index->pprev, index));
+                if (deferred_it != deferred_unlinked_erases.end()) {
+                    auto range = blockman.m_blocks_unlinked.equal_range(index->pprev);
+                    for (auto it = range.first; it != range.second; ++it) {
+                        if (it->second == index) {
+                            blockman.m_blocks_unlinked.erase(it);
+                            break;  // todo: should we make sure this entry is always present in m_blocks_unlinked using some assert maybe?
+                        }
+                    }
+                    deferred_unlinked_erases.erase(deferred_it);
+                }
+
                 CBlock block;
                 block.vtx = std::vector<CTransactionRef>(index->nTx); // Set the number of tx to the prior value.
                 FlatFilePos pos(0, fuzzed_data_provider.ConsumeIntegralInRange<int>(1, 1000));

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -3140,12 +3140,18 @@ CBlockIndex* Chainstate::FindMostWorkChain()
                 }
                 // Remove the entire chain from the set.
                 for (CBlockIndex *pindexFailed = pindexNew; pindexFailed != pindexTest; pindexFailed = pindexFailed->pprev) {
+                    // If we're missing data and not a descendant of an invalid block,
+                    // then add back to m_blocks_unlinked, so that if the block arrives in the future
+                    // we can try adding to setBlockIndexCandidates again.
                     if (fMissingData && !fFailedChain) {
-                        // If we're missing data and not a descendant of an invalid block,
-                        // then add back to m_blocks_unlinked, so that if the block arrives in the future
-                        // we can try adding to setBlockIndexCandidates again.
-                        m_blockman.m_blocks_unlinked.insert(
-                            std::make_pair(pindexFailed->pprev, pindexFailed));
+                        // Avoid duplicate entries in m_blocks_unlinked. If the same entry is
+                        // processed twice in ReceivedBlockTransactions(), it may be re-added to
+                        // setBlockIndexCandidates with a modified nSequenceId, breaking ordering
+                        // guarantees and leading to undefined behavior.
+                        auto range = m_blockman.m_blocks_unlinked.equal_range(pindexFailed->pprev);
+                        if (!std::any_of(range.first, range.second, [&](const auto& p) { return p.second == pindexFailed; })) {
+                            m_blockman.m_blocks_unlinked.emplace(pindexFailed->pprev, pindexFailed);
+                        }
                     }
                     setBlockIndexCandidates.erase(pindexFailed);
                 }
@@ -5336,13 +5342,12 @@ void ChainstateManager::CheckBlockIndex() const
         // Check whether this block is in m_blocks_unlinked.
         auto rangeUnlinked{m_blockman.m_blocks_unlinked.equal_range(pindex->pprev)};
         bool foundInUnlinked = false;
-        while (rangeUnlinked.first != rangeUnlinked.second) {
-            assert(rangeUnlinked.first->first == pindex->pprev);
-            if (rangeUnlinked.first->second == pindex) {
+        for (auto it = rangeUnlinked.first; it != rangeUnlinked.second; ++it) {
+            assert(it->first == pindex->pprev);
+            if (it->second == pindex) {
+                assert(!foundInUnlinked); // No duplicates in m_blocks_unlinked
                 foundInUnlinked = true;
-                break;
             }
-            rangeUnlinked.first++;
         }
         if (pindex->pprev && (pindex->nStatus & BLOCK_HAVE_DATA) && pindexFirstNeverProcessed != nullptr && pindexFirstInvalid == nullptr) {
             // If this block has block data available, some parent was never received, and has no invalid parents, it must be in m_blocks_unlinked.

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -3148,10 +3148,7 @@ CBlockIndex* Chainstate::FindMostWorkChain()
                         // processed twice in ReceivedBlockTransactions(), it may be re-added to
                         // setBlockIndexCandidates with a modified nSequenceId, breaking ordering
                         // guarantees and leading to undefined behavior.
-                        auto range = m_blockman.m_blocks_unlinked.equal_range(pindexFailed->pprev);
-                        if (!std::any_of(range.first, range.second, [&](const auto& p) { return p.second == pindexFailed; })) {
-                            m_blockman.m_blocks_unlinked.emplace(pindexFailed->pprev, pindexFailed);
-                        }
+                        m_blockman.AddUnlinkedBlock(pindexFailed);
                     }
                     setBlockIndexCandidates.erase(pindexFailed);
                 }
@@ -3815,7 +3812,7 @@ void ChainstateManager::ReceivedBlockTransactions(const CBlock& block, CBlockInd
         }
     } else {
         if (pindexNew->pprev && pindexNew->pprev->IsValid(BLOCK_VALID_TREE)) {
-            m_blockman.m_blocks_unlinked.insert(std::make_pair(pindexNew->pprev, pindexNew));
+            m_blockman.AddUnlinkedBlock(pindexNew);
         }
     }
 }

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -5252,6 +5252,24 @@ void ChainstateManager::CheckBlockIndex() const
         assert(((pindex->nStatus & BLOCK_VALID_MASK) >= BLOCK_VALID_TRANSACTIONS) == (pindex->nTx > 0)); // This is pruning-independent.
         // All parents having had data (at some point) is equivalent to all parents being VALID_TRANSACTIONS, which is equivalent to HaveNumChainTxs().
         // HaveNumChainTxs will also be set in the assumeutxo snapshot block from snapshot metadata.
+        // we are checking:
+            // pindexFirstNeverProcessed == nullptr means all the ancestors of pindex are received (nTx is present for all of them)
+            // pindexFirstNotTransactionsValid == nullptr means all the ancestors of pindex have BLOCK_VALID_TRANSACTION
+            // (TODO: nTx and BLOCK_VALID_TRANSACTION are set in same function RBT, not sure why we have both)
+            // both of these means we have set m_chain_tx_count
+
+        // even if some ancestor of pindex doesn't have data because it was pruned away
+        // we still retain nTx and BLOCK_VALID_TRANSACTION
+        // so why is the fuzz test failing in this theoretical scenario
+        // 1. parent not received
+        // 2. child received (HAVE_DATA, nTx, m_chain_tx_count=0) - add child to m_blocks_unlinked
+        // 3. child pruned away (no HAVE_DATA, nTx, m_chain_tx_count=0) - remove child from m_blocks_unlinked
+        // 4. parent received  (HAVE_DATA, nTx, m_chain_tx_count)
+        // CBI on child (all ancestors of pindex have been received but m_chain_tx_count = 0)
+
+        // it's impossible IRL to prune child (without pruning parent)
+        // so the fuzz test isn't actually IRL and i'm going to remove the m_blocks_unlinked clearing
+        // when we prue a block so that RBT can do the needful and update m_chain_tx_count
         assert((pindexFirstNeverProcessed == nullptr || pindex == snap_base) == pindex->HaveNumChainTxs());
         assert((pindexFirstNotTransactionsValid == nullptr || pindex == snap_base) == pindex->HaveNumChainTxs());
         assert(pindex->nHeight == nHeight); // nHeight must be consistent.

--- a/test/functional/feature_pruning.py
+++ b/test/functional/feature_pruning.py
@@ -236,8 +236,8 @@ class PruneTest(BitcoinTestFramework):
         self.nodes[2].getblock(self.nodes[2].getblockhash(self.forkheight))
 
         first_reorg_height = self.nodes[2].getblockcount()
-        curchainhash = self.nodes[2].getblockhash(self.mainchainheight)
-        self.nodes[2].invalidateblock(curchainhash)
+        block_hash_1295 = self.nodes[2].getblockhash(1295)
+        self.nodes[2].invalidateblock(block_hash_1295)
         goalbestheight = self.mainchainheight
         goalbesthash = self.mainchainhash2
 
@@ -252,7 +252,7 @@ class PruneTest(BitcoinTestFramework):
         if self.nodes[2].getblockcount() < self.mainchainheight:
             blocks_to_mine = first_reorg_height + 1 - self.mainchainheight
             self.log.info(f"Rewind node 0 to prev main chain to mine longer chain to trigger redownload. Blocks needed: {blocks_to_mine}")
-            self.nodes[0].invalidateblock(curchainhash)
+            self.nodes[0].invalidateblock(block_hash_1295)
             assert_equal(self.nodes[0].getblockcount(), self.mainchainheight)
             assert_equal(self.nodes[0].getbestblockhash(), self.mainchainhash2)
             goalbesthash = self.generate(self.nodes[0], blocks_to_mine, sync_fun=self.no_op)[-1]

--- a/test/functional/feature_pruning.py
+++ b/test/functional/feature_pruning.py
@@ -6,7 +6,6 @@
 
 WARNING:
 This test uses 4GB of disk space.
-This test takes 30 mins or more (up to 2 hours)
 """
 import os
 
@@ -351,17 +350,15 @@ class PruneTest(BitcoinTestFramework):
         self.log.info("Stop and start pruning node to trigger wallet rescan")
         self.restart_node(2, extra_args=["-prune=550"])
 
-        wallet_info = self.nodes[2].getwalletinfo()
-        self.wait_until(lambda: wallet_info["scanning"] == False)
-        self.wait_until(lambda: wallet_info["lastprocessedblock"]["height"] == self.nodes[2].getblockcount())
+        self.wait_until(lambda: self.nodes[2].getwalletinfo()["scanning"] == False)
+        self.wait_until(lambda: self.nodes[2].getwalletinfo()["lastprocessedblock"]["height"] == self.nodes[2].getblockcount())
 
         # check that wallet loads successfully when restarting a pruned node after IBD.
         # this was reported to fail in #7494.
         self.restart_node(5, extra_args=["-prune=550", "-blockfilterindex=1"]) # restart to trigger rescan
 
-        wallet_info = self.nodes[5].getwalletinfo()
-        self.wait_until(lambda: wallet_info["scanning"] == False)
-        self.wait_until(lambda: wallet_info["lastprocessedblock"]["height"] == self.nodes[0].getblockcount())
+        self.wait_until(lambda: self.nodes[5].getwalletinfo()["scanning"] == False)
+        self.wait_until(lambda: self.nodes[5].getwalletinfo()["lastprocessedblock"]["height"] == self.nodes[0].getblockcount())
 
     def run_test(self):
         self.log.info("Warning! This test requires 4GB of disk space")


### PR DESCRIPTION
this is a class of fuzz tests where we don't care about why/how block is valid/invalid - but we know the end result about the block's validity status. with this info - we do a range of activities like forks in block index, receiving the block data, reorging + pruning.

things we might care about that CheckBlockIndex reads:
BlockManager:            
  - `m_block_index`
  - `m_blocks_unlinked`                                                                
  - `m_have_pruned`
  
  ChainstateManager:   (`m_best_invalid` is not here)                                                                                                       
  - `m_best_header`
  - a chainstate's `setBlockIndexCandidates`
 
questions:
1. can we make the pruning behaviour in fuzz test more real world?
    1. IRL if we prune a block, all it's parents are pruned as well - so that there are no random holes.
         - `CheckBlockIndex` condition fails when child is pruned away and parent is received later (all ancestors of pindex=child have been received but m_chain_tx_count = 0)
    2. we don't prune `MIN_BLOCKS_TO_KEEP = 288` blocks from tip
         - if we reduce `MIN_BLOCKS_TO_KEEP = 2` for example in the fuzz test - I don't think it will prevent block from `setBlockIndexCandidates` being selected as block to prune. causes UB when this block is present in the SBI internal tree and we call RBT on it again.
2. hacked around 1.1. by not clearing m_blocks_unlinked when we prune  - if we later receive the parent in RBT, it will detect child using m_blocks_unlinked and m_chain_tx_count will be updated and 1.1 won't fail (letting it "naturally heal").  make sure the m_blocks_unlinked clearing which we deleted gets called at least once before CBI (right before CBI or before we redownload pruned block) so that the "if this block has no data, it cannot be in m_blocks_unlinked" CBI condition doesn't fail. hack around 1.2 by refusing to prune blocks in SBI.
    - feel like these hacks hurt coverage since the fuzzer doesn't crash anymore lol. need to measure it better?
    - slightly related mzumsande's  [comment](https://github.com/bitcoin/bitcoin/pull/35168#discussion_r3162492297). 
    
other extensions:
1. LBI coverage?  35050 is kind of a variant of 31512.
